### PR TITLE
feat: add manager attribute for organizational hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,32 @@ make start
 
 All users have password matching their username (e.g., username: `fry`, password: `fry`):
 
-| Username | Email | Groups |
-|----------|-------|--------|
-| fry | fry@planetexpress.com | ship_crew, delivery_crew |
-| leela | leela@planetexpress.com | ship_crew, delivery_crew, management |
-| bender | bender@planetexpress.com | ship_crew, delivery_crew |
-| professor | professor@planetexpress.com | scientists, management |
-| amy | amy@planetexpress.com | scientists, interns |
-| hermes | hermes@planetexpress.com | management, bureaucrats |
-| zoidberg | zoidberg@planetexpress.com | - |
-| scruffy | scruffy@planetexpress.com | - |
-| nibbler | nibbler@planetexpress.com | ship_crew |
+| Username | Title | Department | Manager | Groups |
+|----------|-------|------------|---------|--------|
+| fry | Delivery Boy | Delivery | leela | ship_crew, delivery_crew |
+| leela | Ship Captain | Command | hermes | ship_crew, delivery_crew, management |
+| bender | Ship Cook | Ship Operations | leela | ship_crew, delivery_crew |
+| professor | CEO and Founder | Executive | - | scientists, management |
+| amy | Intern | Engineering | leela | scientists, interns |
+| hermes | Bureaucrat Grade 34 | Administration | professor | management, bureaucrats |
+| zoidberg | Staff Doctor | Medical | professor | - |
+| scruffy | Janitor | Maintenance | professor | - |
+| nibbler | Ship Mascot | Operations | - | ship_crew |
+
+## Organizational Hierarchy
+
+```
+Professor Farnsworth (CEO)
+├── Hermes Conrad (Operations Manager)
+│   └── Leela (Ship Captain)
+│       ├── Fry (Delivery Boy)
+│       ├── Bender (Ship Cook)
+│       └── Amy Wong (Intern)
+├── Dr. Zoidberg (Staff Doctor)
+└── Scruffy (Janitor)
+
+Nibbler (Independent - Ship Mascot/Secret Agent)
+```
 
 ## Groups
 
@@ -82,12 +97,30 @@ ldapsearch -x -H ldap://localhost \
   -b "dc=planetexpress,dc=com" "(sAMAccountName=fry)" memberOf
 ```
 
+### Check User's Manager
+```bash
+ldapsearch -x -H ldap://localhost \
+  -D "cn=admin,dc=planetexpress,dc=com" \
+  -w "GoodNewsEveryone" \
+  -b "dc=planetexpress,dc=com" "(uid=fry)" manager
+```
+
+### Find Direct Reports
+```bash
+ldapsearch -x -H ldap://localhost \
+  -D "cn=admin,dc=planetexpress,dc=com" \
+  -w "GoodNewsEveryone" \
+  -b "dc=planetexpress,dc=com" "(manager=uid=leela,ou=mutants,dc=planetexpress,dc=com)" uid cn title
+```
+
 ## AD Compatibility Features
 
 - `sAMAccountName` attribute for all users
 - `memberOf` overlay for automatic group membership
 - AD-compatible `group` objectClass
 - Standard AD group types
+- `manager` attribute for organizational hierarchy
+- `userPrincipalName` in user@domain format
 
 ## Docker Image
 

--- a/ldif/02-users.ldif
+++ b/ldif/02-users.ldif
@@ -24,6 +24,7 @@ employeeType: Human
 employeeNumber: PE001
 departmentNumber: Delivery
 telephoneNumber: +1-212-555-0101
+manager: uid=leela,ou=mutants,dc=planetexpress,dc=com
 sAMAccountName: fry
 userPrincipalName: fry@planetexpress.com
 
@@ -50,6 +51,7 @@ employeeType: Mutant
 employeeNumber: PE002
 departmentNumber: Command
 telephoneNumber: +1-212-555-0102
+manager: uid=hermes,ou=people,dc=planetexpress,dc=com
 sAMAccountName: leela
 userPrincipalName: leela@planetexpress.com
 
@@ -77,6 +79,7 @@ employeeNumber: PE003
 departmentNumber: Ship Operations
 telephoneNumber: +1-212-555-0103
 description: Bending Unit 22, Serial 2716057
+manager: uid=leela,ou=mutants,dc=planetexpress,dc=com
 sAMAccountName: bender
 userPrincipalName: bender@planetexpress.com
 
@@ -129,6 +132,7 @@ employeeType: Human
 employeeNumber: PE005
 departmentNumber: Engineering
 telephoneNumber: +1-212-555-0105
+manager: uid=leela,ou=mutants,dc=planetexpress,dc=com
 sAMAccountName: amy
 userPrincipalName: amy@planetexpress.com
 
@@ -155,6 +159,7 @@ employeeType: Human
 employeeNumber: PE006
 departmentNumber: Administration
 telephoneNumber: +1-212-555-0106
+manager: uid=professor,ou=people,dc=planetexpress,dc=com
 sAMAccountName: hermes
 userPrincipalName: hermes@planetexpress.com
 
@@ -181,6 +186,7 @@ employeeType: Alien
 employeeNumber: PE007
 departmentNumber: Medical
 telephoneNumber: +1-212-555-0107
+manager: uid=professor,ou=people,dc=planetexpress,dc=com
 sAMAccountName: zoidberg
 userPrincipalName: zoidberg@planetexpress.com
 
@@ -207,6 +213,7 @@ employeeType: Human
 employeeNumber: PE008
 departmentNumber: Maintenance
 telephoneNumber: +1-212-555-0108
+manager: uid=professor,ou=people,dc=planetexpress,dc=com
 sAMAccountName: scruffy
 userPrincipalName: scruffy@planetexpress.com
 


### PR DESCRIPTION
- Add manager DN field to all user entries showing reporting structure
- Establish Futurama-accurate org hierarchy:
  - Professor (CEO) at the top
  - Hermes manages operations, reporting to Professor
  - Leela captains delivery crew, reporting to Hermes
  - Fry, Bender, and Amy report to Leela
  - Zoidberg and Scruffy report directly to Professor
- Update README with organizational chart and manager examples
- Enhance test user documentation with titles and departments
